### PR TITLE
Npmify

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@
 
 ## Installation
 
+Either preinstall using one of the methods described below, or use `npx`
+to install/run `npm-diff` on demand:
+
+```bash
+npx npm-diff
+```
+
+### Globally installed as npm module
+
+```bash
+npm install npm-diff -g
+```
+
+### Manual install
+
+Clone this repository and run:
+
 ```bash
 $ make install
 ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "npm-diff",
+  "version": "0.0.0",
+  "description": "Diff two versions of a node module",
+  "bin": "npm-diff",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/juliangruber/npm-diff.git"
+  },
+  "keywords": [
+    "npm",
+    "diff",
+    "difference",
+    "version",
+    "versions",
+    "compare",
+    "changes",
+    "package",
+    "module"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/juliangruber/npm-diff/issues"
+  },
+  "homepage": "https://github.com/juliangruber/npm-diff#readme"
+}


### PR DESCRIPTION
This PR partly fixes #6 by allowing you to publish to npm so that it can be installed and run directly from there, eg:

```
npx npm-diff <module> <versionA> <versionB>
```

The only thing is that npm currently holds the name for [`npm-diff`](https://www.npmjs.com/package/npm-diff) because it's been in use previously, but all you have to do is write to them to get the name handed over I think:

> This package name is not currently in use, but was formerly occupied by another package. To avoid malicious use, npm is hanging on to the package name, but loosely, and we'll probably give it to you if you want it.
> 
> You may adopt this package by contacting support@npmjs.com and requesting the name.