### PR TITLE
Add option to display the diff in color (use global installed colordiff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,7 @@ Usage: npm-diff <module> <versionA> <versionB>
 $ npm-diff intersect 0.0.0 0.1.0 | less
 ``` 
 
-  Pipe to [colordiff](http://www.colordiff.org) for colored git like diffs:
-
-```bash
-$ npm-diff intersect 0.0.0 0.1.0 | colordiff | less -R
-```
-
+  If [colordiff](http://www.colordiff.org) is installed, the output will be colored.
 ## Sponsors
 
 This module is proudly supported by my [Sponsors](https://github.com/juliangruber/sponsors)!

--- a/npm-diff
+++ b/npm-diff
@@ -8,12 +8,14 @@
 # (c) 2018 Julian Gruber <mail@juliangruber.com>
 #
 
+
 set -e
 
 # arguments
 
 if [[ $# != 3 ]]; then
   echo "Usage: npm-diff <module> <versionA> <versionB>"
+  echo "Example: npm-diff intersect 0.0.0 0.1.0"
   exit 1
 fi
 
@@ -56,13 +58,20 @@ for job in `jobs -p`; do wait $job || exit 1; done
 
 # diff
 
-diff \
-  --recursive \
-  --unified \
-  --exclude test \
-  --exclude Makefile \
-  $a $b \
-  | egrep -v "\"readme\"|\"_id\"|\"_from\"|\"_resolved\""
+diffCommand='diff 
+  --recursive 
+  --unified 
+  --exclude test 
+  --exclude Makefile 
+  $a $b 
+  | egrep -v "\"readme\"|\"_id\"|\"_from\"|\"_resolved\""'
+
+# If it is running in a terminal AND colordiff is installed, use it
+if [ -t 1 -a -x "$(command -v colordiff)" ]; then
+    diffCommand+="| colordiff"
+fi
+
+eval $diffCommand
 
 # cleanup
 


### PR DESCRIPTION
Hi !

I have added an option to inform a parameter when calling npm-diff so the output is colored. Internally it will check it `colordiff` is installed and if so, pipe the npm-diff result to colordiff. If colordiff is not installed, it will give an error (so it gets easier to user identify that it miss a dependency). If the option is not informed, it behaves as before (no color output)

This is exactly the behavior suggested in the README but easier to be accomplished as you just need to add an `-c` option in the execution, like this:

`npm-diff -c intersect 0.0.0 0.1.0`

Please let me know if you think this could be useful or not and if you have any question / suggestion !

Thank you !