### PR TITLE
feat: add `--new-file` arg to diff command

### DIFF
--- a/npm-diff
+++ b/npm-diff
@@ -61,6 +61,7 @@ for job in `jobs -p`; do wait $job || exit 1; done
 diffCommand='diff 
   --recursive 
   --unified 
+  --new-file 
   --exclude test 
   --exclude Makefile 
   $a $b 


### PR DESCRIPTION
When i compare two versions of a package new/deleted files aren't diffed correctly (in my opinion).

### Example:

```diff
diff --recursive --unified --exclude test --exclude Makefile <package@1> <package@2>

# new files
Only in <package@1>: some-file-1.txt

# deleted files
Only in <package@2>: some-file-2.txt
```

#### After this PR:
```diff
diff --recursive --unified --new-file --exclude test --exclude Makefile <package@1> <package@2>

# new files
--- <package@1>/some-file-1.txt	1970-01-01 01:00:00.000000000 +0100
+++ <package@2>/some-file-1.txt	2021-09-09 11:11:11.000000000 +0200
@@ -0,0 +1,9 @@
+this is a test

# deleted files
--- <package@1>/some-file-2.txt	1970-01-01 01:00:00.000000000 +0100
+++ <package@2>/some-file-2.txt	2021-09-09 11:11:11.000000000 +0200
@@ -1,9 +0,0 @@
-this is another test
```

https://man7.org/linux/man-pages/man1/diff.1.html